### PR TITLE
actually undefine ntpd_crypto by default as intended

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,4 +27,4 @@ ntpd_restrict:
 ntpd_log_stats: no
 
 # undefined crypto settings
-ntpd_crypto: ''
+# ntpd_crypto: ''


### PR DESCRIPTION
the current solution does not undefine it. so if there is no value for ntpd_crypto configured on the cookbook, the service will fail to start
