### PR TITLE
Adding enable/disable functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Role Variables
 Here are the variables as well as the defaults:
 
 ```yaml
+
+# Is ntp enabled? (default: yes)
+ntpd_enabled: yes
+
 # The 0, 1, 2 and 3.pool.ntp.org names point to a random set of servers that
 # will change every hour. See http://www.pool.ntp.org/en/use.html
 ntpd_sources:

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ Here are the variables as well as the defaults:
 
 ```yaml
 
-# Is ntp enabled? (default: yes)
-ntpd_enabled: yes
+# Is ntp enabled on reboot? (default: true)
+ntpd_enabled: true
+
+# What state should this role set ntp service to
+ntpd_state: "started"
 
 # The 0, 1, 2 and 3.pool.ntp.org names point to a random set of servers that
 # will change every hour. See http://www.pool.ntp.org/en/use.html

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 
 # is ntp enabled?
 ntpd_enabled: true
+ntpd_state: "started"
 
 # The 0, 1, 2 and 3.pool.ntp.org names point to a random set of servers that
 # will change every hour.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 
 # /vars/main.yml for ansible-ntpd role.
 
+# is ntp enabled?
+ntpd_enabled: true
+
 # The 0, 1, 2 and 3.pool.ntp.org names point to a random set of servers that
 # will change every hour.
 ntpd_sources:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,5 @@
 
 - name: restart ntpd
   service: name={{ ntpd_svc_name }} state=restarted enabled=yes
+  when: ntpd_enabled
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,3 +13,13 @@
   notify:
    - restart ntpd
   tags: ntp
+
+- name: ensure ntpd is started
+  service: name={{ ntpd_svc_name }} state=started enabled=yes
+  when: ntpd_enabled
+  tags: ntp
+
+- name: ensure ntpd is stopped
+  service: name={{ ntpd_svc_name }} state=stopped enabled=no
+  when: not ntpd_enabled
+  tags: ntp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,12 +14,9 @@
    - restart ntpd
   tags: ntp
 
-- name: ensure ntpd is started
-  service: name={{ ntpd_svc_name }} state=started enabled=yes
-  when: ntpd_enabled
-  tags: ntp
-
-- name: ensure ntpd is stopped
-  service: name={{ ntpd_svc_name }} state=stopped enabled=no
-  when: not ntpd_enabled
+- name: start/stop/enable ntpd service
+  service:
+    name: "{{ ntpd_svc_name }}"
+    state: "{{ ntpd_state }}"
+    enabled: "{{ ntpd_enabled }}"
   tags: ntp


### PR DESCRIPTION
By default NTP is now enabled, which improves the previous
behaivour of not starting NTP if it's not running and the
config has not changed
