### PR TITLE
add ansible version <2.0 support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,8 +5,14 @@
   tags: ntp
 
 - name: Install ntp packages
-  package: name={{ ntpd_pkgs }} state={{ ntpd_pkg_state }}
+  apt: name={{ ntpd_pkgs }} state={{ ntpd_pkg_state }}
   tags: ntp
+  when: ansible_os_family == "Debian"
+
+- name: main | installing ntp package
+  yum: name={{ ntpd_pkgs }} state={{ ntpd_pkg_state }}
+  tags: ntp
+  when: ansible_os_family == "RedHat"
 
 - name: Copy the ntp.conf template file
   template: src=ntp.conf.j2 dest=/etc/ntp.conf


### PR DESCRIPTION
The "package" install primative was introduced in Ansible 2.0 earlier versions
do not support it.
