### PR TITLE
Add Suse 11 support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,9 @@ galaxy_info:
       - quantal
       - raring
       - saucy
+   - name: SLES
+     versions:
+      - 11
   galaxy_tags:
    - ntp
    - system

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -48,7 +48,9 @@ includefile /etc/ntp/crypto/pw
 
 # Key file containing the keys and key identifiers used when operating
 # with symmetric key cryptography.
-keys /etc/ntp/keys
+{% if ntpd_keysfile is defined %}
+keys {{ ntpd_keysfile }}
+{% endif %}
 
 # Specify the key identifiers which are trusted ex:.
 #trustedkey 4 8 42

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,3 +4,5 @@ ntpd_pkgs:
   - ntp
 
 ntpd_svc_name: ntp
+
+ntpd_keysfile: "/etc/ntp/keys"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,3 +4,5 @@ ntpd_pkgs:
   - ntp
 
 ntpd_svc_name: ntpd
+
+ntpd_keysfile: "/etc/ntp/keys"

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -1,0 +1,10 @@
+---
+ntpd_pkgs:
+  - python-selinux
+  - ntp
+
+ntpd_svc_name: ntp
+
+# Deliberately left indefined.
+# see https://bugzilla.novell.com/show_bug.cgi?id=542098
+# ntpd_keysfile: "/etc/ntp.keys"


### PR DESCRIPTION
Of note this makes the specification of
where the NTP keys file platform specific
and optional
